### PR TITLE
Analyze without erorrs valid coffeescrpt file with only comments

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -42,7 +42,7 @@ getAst = (source, ignoreErrors) ->
       line: ast.locationData.first_line
     },
     end: {
-      line: lastExp.locationData.last_line
+      line: (lastExp ? ast).locationData.last_line
     }
   }
   ast

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -32,6 +32,10 @@ suite 'escomplex-coffee:', ->
       assert.doesNotThrow ->
         escomplex.analyse 'foo = "#{foo}"\nunless foo isnt "foo"\n  console.log "foo"\n  foo = undefined\nelse\n  console.log foo'
 
+    test 'analyse does not throw when source is valid CoffeeScript comment', ->
+      assert.doesNotThrow ->
+        escomplex.analyse '# comment'
+
     test 'analyse does not throw when source is valid array', ->
       assert.doesNotThrow ->
         escomplex.analyse [


### PR DESCRIPTION
When analyzing file which only contains comments, there is an error `TypeError: Cannot read property 'locationData' of undefined` as there are no expressions in `ast.expressions`.

```
TypeError: Cannot read property 'locationData' of undefined
    at getAst (.../node_modules/escomplex-coffee/lib/index.js:52:22)
    at .../node_modules/escomplex-coffee/lib/index.js:17:16
    at Array.map (native)
```

This pull request contains a test case and a fix.